### PR TITLE
CSS variables are all now customisable. uuid changed to nanoid.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@types/uuid": "^8.3.0",
-    "uuid": "^8.3.2"
+    "nanoid": "^3.1.30"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.33.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,41 @@
           </template>
         </vue-collapsible-panel>
       </vue-collapsible-panel-group>
+
+      <vue-collapsible-panel-group
+        accordion
+        border-color="#FFFF01"
+        base-color="#0000FF"
+        bg-color-header="#66ff66"
+        bg-color-header-hover="#00ff00"
+        bg-color-header-active="#00ffff"
+        bg-color-body="#ffaaaa"
+      >
+        <vue-collapsible-panel :expanded="false">
+          <template #title>
+            Panel 1
+          </template>
+          <template #content>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lobortis purus quis leo efficitur, egestas varius justo rhoncus. Nunc a pulvinar metus. Nunc mollis viverra varius. Fusce varius nunc ante, eget congue sem tristique sagittis. Aliquam erat volutpat.
+          </template>
+        </vue-collapsible-panel>
+        <vue-collapsible-panel :expanded="false">
+          <template #title>
+            Panel 2
+          </template>
+          <template #content>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lobortis purus quis leo efficitur, egestas varius justo rhoncus. Nunc a pulvinar metus. Nunc mollis viverra varius. Fusce varius nunc ante, eget congue sem tristique sagittis. Aliquam erat volutpat.
+          </template>
+        </vue-collapsible-panel>
+        <vue-collapsible-panel :expanded="false">
+          <template #title>
+            Panel 3
+          </template>
+          <template #content>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam lobortis purus quis leo efficitur, egestas varius justo rhoncus. Nunc a pulvinar metus. Nunc mollis viverra varius. Fusce varius nunc ante, eget congue sem tristique sagittis. Aliquam erat volutpat.
+          </template>
+        </vue-collapsible-panel>
+      </vue-collapsible-panel-group>
     </div>
 
     <div class="bottom-links">
@@ -153,7 +188,7 @@ export default defineComponent({
 
     .vcpg {
       margin: 0 10px;
-      width: 500px;
+      width: 350px;
     }
   }
 

--- a/src/components/VueCollapsiblePanel.vue
+++ b/src/components/VueCollapsiblePanel.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script lang="ts">
-import { v4 as uuid } from 'uuid'
+import { nanoid, customAlphabet } from 'nanoid'
 import {
   computed,
   defineComponent,
@@ -62,6 +62,8 @@ import { VNodeArrayChildren } from '@vue/runtime-core'
 import { toggleIcon } from '@/components/vue-collapsible-panel.constant'
 import { useCollapsiblePanelStore } from '@/components/composables/vue-collapsible-panel.store'
 
+customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ', 21)
+
 export default defineComponent({
   name: 'VueCollapsiblePanel',
   props: {
@@ -71,7 +73,7 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const idPanel = `panel-${uuid()}`
+    const idPanel = `panel-${nanoid()}`
     const panelRef = ref<HTMLElement>()
     const bodyRef = ref<HTMLElement>()
     const bodyContentRef = ref<HTMLElement>()
@@ -84,7 +86,7 @@ export default defineComponent({
     const body = computed(
       () => ({
         hasContent: context.slots.content && (context.slots.content()[0].children as VNodeArrayChildren).length > 0,
-        dataKey: uuid(),
+        dataKey: nanoid(),
       }),
     )
 
@@ -150,6 +152,7 @@ export default defineComponent({
       display: flex;
       padding: 12px;
       pointer-events: none;
+      overflow: hidden;
 
       #{$root}--expandable & {
         pointer-events: auto;

--- a/src/components/VueCollapsiblePanelGroup.vue
+++ b/src/components/VueCollapsiblePanelGroup.vue
@@ -9,13 +9,15 @@
 </template>
 
 <script lang="ts">
-import { v4 as uuid } from 'uuid'
+import { nanoid, customAlphabet } from 'nanoid'
 import {
   defineComponent,
   ref,
 } from 'vue'
 import { useCollapsiblePanelStore } from '@/components/composables/vue-collapsible-panel.store'
 import { lightenDarkenColor } from '@/utils/color.util'
+
+customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ', 21)
 
 export default defineComponent({
   name: 'VueCollapsiblePanelGroup',
@@ -28,17 +30,37 @@ export default defineComponent({
       type: String,
       default: '#333333',
     },
+    borderColor: {
+      type: String,
+      default: null,
+    },
+    bgColorHeader: {
+      type: String,
+      default: null,
+    },
+    bgColorHeaderHover: {
+      type: String,
+      default: null,
+    },
+    bgColorHeaderActive: {
+      type: String,
+      default: null,
+    },
+    bgColorBody: {
+      type: String,
+      default: '#fff',
+    },
   },
   setup(props) {
-    const idGroup = ref(`group-${uuid()}`)
+    const idGroup = ref(`group-${nanoid()}`)
     const { setGroupAccordionStatus } = useCollapsiblePanelStore()
     const cssColorVars = {
       '--base-color': props.baseColor,
-      '--border-color': lightenDarkenColor(props.baseColor, 160),
-      '--bg-color-header': lightenDarkenColor(props.baseColor, 170),
-      '--bg-color-header-hover': lightenDarkenColor(props.baseColor, 175),
-      '--bg-color-header-active': lightenDarkenColor(props.baseColor, 170),
-      '--bg-color-body': '#fff',
+      '--border-color': lightenDarkenColor(props.borderColor, props.baseColor, 160),
+      '--bg-color-header': lightenDarkenColor(props.bgColorHeader, props.baseColor, 170),
+      '--bg-color-header-hover': lightenDarkenColor(props.bgColorHeaderHover, props.baseColor, 175),
+      '--bg-color-header-active': lightenDarkenColor(props.bgColorHeaderActive, props.baseColor, 170),
+      '--bg-color-body': lightenDarkenColor(props.bgColorBody, '#fff', 0),
     }
 
     setGroupAccordionStatus(idGroup.value, props.accordion)

--- a/src/utils/color.util.ts
+++ b/src/utils/color.util.ts
@@ -4,7 +4,9 @@ const normalizedPartialColor = (partial: number): number => {
   return partial
 }
 
-export const lightenDarkenColor = (hexColor: string, amount: number) => {
+export const lightenDarkenColor = (paramHexColor: string, hexColor: string, amount: number) => {
+  if (paramHexColor) return paramHexColor
+
   const color = hexColor.replace('#', '')
   const colorNumber = parseInt(color, 16)
 
@@ -12,5 +14,5 @@ export const lightenDarkenColor = (hexColor: string, amount: number) => {
   const blue = normalizedPartialColor(((colorNumber >> 8) & 0x00FF) + amount)
   const green = normalizedPartialColor((colorNumber & 0x0000FF) + amount)
 
-  return '#' + (green | (blue << 8) | (red << 16)).toString(16)
+  return `#${(green | (blue << 8) | (red << 16)).toString(16)}`
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,11 +1075,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@types/webpack-dev-server@^3.11.0":
   version "3.11.2"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz#73915a7d9e0a9b5e010a2388a46f68ab3f770ef8"
@@ -6290,6 +6285,11 @@ nanoid@^3.1.20:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
   integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
 
+nanoid@^3.1.30:
+  version "3.1.30"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
+  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9265,11 +9265,6 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
Only `base-color` was in reality customisable as all other CSS-variables was inferred from this. This functionality has been preserved, but now all variables (`base-color`, `border-color`, `bg-color-header`, `bg-color-header-hover`, `bg-color-header-active`, and `bg-color-body`) can be set to a wanted value.

Added `overflow: hidden` to header to avoid bad rendering. 

The `uuid` package has been swapped for `nanoid` which is faster, a lot leaner (108 bytes), more secure, and has no external dependencies.

No need to update documentation, as the customisation is already documented.